### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.py.yaml
+++ b/.github/workflows/test.py.yaml
@@ -1,4 +1,6 @@
 name: Test coverage report
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/ONSdigital/blaise-cma-functions/security/code-scanning/2](https://github.com/ONSdigital/blaise-cma-functions/security/code-scanning/2)

To fix the problem, we should explicitly define the `permissions` block for the workflow. The best way to enforce least privilege is to add a `permissions` block at the root level of the workflow YAML file, applying restrictions to all jobs unless overridden. In this workflow, the jobs only need to check out code, run tests, and upload code coverage data. None of these require write permissions on repository contents. Therefore, we should insert the following at the top level (right after the workflow `name`):  
```yaml
permissions:
  contents: read
```
This restricts the GITHUB_TOKEN permissions for all jobs to only reading repo contents, adhering to the principle of least privilege. The change should be made in `.github/workflows/test.py.yaml`, immediately after line 1 (the `name` line), and before the `on:` block.

No further code, methods, or imports are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
